### PR TITLE
Configure Neon-ready database settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Local env ###
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Vibe Guide
+
+**Vibe Guide** is a Java Spring Boot backend with a React Native (Expo Go) mobile app.  
+It helps users discover the best places in Skopje to hang out, enjoy food, drinks, and events.  
+
+---
+
+## ✨ Features
+- Categorization of places based on their traits:
+  - Music genre
+  - Type of venue (restaurant, lounge bar, coffee shop, pub, etc.)
+  - Type of food and drinks offered
+  - Atmosphere (casual, fancy, cozy, etc.)
+- Scoring and grading places based on traits for more accurate recommendations.
+- Individual venue profiles where owners can:
+  - Publish events (concerts, parties, celebrations, etc.)
+  - Share daily highlights (special offers or important announcements).
+
+---
+
+## 🎯 Motivation
+We often face the same question: *"Where should we go out with friends?"*  
+Vibe Guide was created to make that decision easier — not just for us, but for anyone who wants to explore and get to know Skopje better.  
+By applying filters, users can quickly discover a selection of venues that match their preferences.  
+
+---
+
+## 🛠️ Technologies
+- **Backend:** Java Spring Boot  
+- **Frontend:** React Native (Expo Go)  
+- **Database:** PostgreSQL  
+- **APIs:** Google Maps API  
+
+---
+
+## 👥 User Roles
+
+### 👤 User
+- Edit personal profile.  
+- Browse venues, events, and news.  
+- Add venues to favorites.  
+
+### 🏪 Admin (Venue Owner/Manager)
+- Edit their profile and their venue’s profile.  
+- Post events related to their venue.  
+- Publish news and daily offers.  
+
+### 🛡 SuperAdmin
+- Manage user and venue profiles.  
+- Approve new Admin accounts (venue owners/managers).  
+
+---
+
+## 🚀 Getting Started
+
+### Backend Setup
+1. Create a Neon project at [neon.com](https://neon.com/) and open the `Connect` modal for your database.
+2. Copy the direct `Java / JDBC` connection details.
+3. Set the Spring datasource variables before starting the backend.
+
+PowerShell example:
+
+```powershell
+$env:SPRING_DATASOURCE_URL="jdbc:postgresql://ep-xxxxx.us-east-2.aws.neon.tech/neondb?sslmode=require&channelBinding=require"
+$env:SPRING_DATASOURCE_USERNAME="neondb_owner"
+$env:SPRING_DATASOURCE_PASSWORD="your-neon-password"
+```
+
+Optional: keep Liquibase on a direct Neon endpoint even if the runtime datasource later uses a pooled `-pooler` host.
+
+```powershell
+$env:SPRING_LIQUIBASE_URL=$env:SPRING_DATASOURCE_URL
+$env:SPRING_LIQUIBASE_USER=$env:SPRING_DATASOURCE_USERNAME
+$env:SPRING_LIQUIBASE_PASSWORD=$env:SPRING_DATASOURCE_PASSWORD
+```
+
+Notes:
+- This app runs Liquibase migrations on startup, so a direct Neon connection is the safest default.
+- Neon recommends TLS plus channel binding for secure Postgres connections, and the JDBC URL above uses the PostgreSQL Java driver's `channelBinding=require` parameter.
+- For local Postgres development, the app still falls back to `jdbc:postgresql://localhost:5432/vibe_guide` with `postgres/postgres`.
+
+4. Build and run the backend:  
+   ```bash
+   ./mvnw spring-boot:run
+   ```

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,10 @@
 spring.application.name=vibe_guide
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/vibe_guide
-spring.datasource.username=postgres
-spring.datasource.password=15881577.p
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/vibe_guide?sslmode=disable}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:postgres}
+spring.datasource.hikari.maximum-pool-size=${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE:5}
+spring.datasource.hikari.minimum-idle=${SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE:1}
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
@@ -10,3 +12,6 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/master.xml
+spring.liquibase.url=${SPRING_LIQUIBASE_URL:${spring.datasource.url}}
+spring.liquibase.user=${SPRING_LIQUIBASE_USER:${spring.datasource.username}}
+spring.liquibase.password=${SPRING_LIQUIBASE_PASSWORD:${spring.datasource.password}}


### PR DESCRIPTION
## Summary
- switch datasource config to environment-based settings for Neon
- allow separate Liquibase connection settings for direct Neon endpoints
- document the Neon JDBC setup flow and ignore local env files

## Verification
- attempted to run mvnw test, but Maven dependency resolution is currently blocked by a local PKIX certificate trust error while fetching from Maven Central